### PR TITLE
Add missing css source maps

### DIFF
--- a/.wvr/build-config.js
+++ b/.wvr/build-config.js
@@ -62,8 +62,12 @@ const config = {
       to: './resources/styles/html5-boilerplate/dist/css/normalize.css',
     },
     {
-      from: './node_modules/bootstrap/dist/css/bootstrap.css',
-      to: './resources/styles/bootstrap/dist/css/bootstrap.css',
+      from: './node_modules/bootstrap/dist/css/bootstrap.min.css',
+      to: './resources/styles/bootstrap/dist/css/bootstrap.min.css',
+    },
+    {
+      from: './node_modules/bootstrap/dist/css/bootstrap.min.css.map',
+      to: './resources/styles/bootstrap/dist/css/bootstrap.min.css.map',
     },
   ],
   entry: {

--- a/app/index.html
+++ b/app/index.html
@@ -20,7 +20,7 @@
 
   <link rel="stylesheet" href="resources/styles/html5-boilerplate/dist/css/normalize.css">
 
-  <link rel="stylesheet" href="resources/styles/bootstrap/dist/css/bootstrap.css">
+  <link rel="stylesheet" href="resources/styles/bootstrap/dist/css/bootstrap.min.css">
 
   <link rel="stylesheet" type='text/css' href="resources/styles/app.css">
 


### PR DESCRIPTION
# Description

Adds missing css source maps to build in .wvr/build-config.js

Fixes #59 

# How Has This Been Tested?

Deployed to dev with no warnings in log. https://labs.library.tamu.edu/get-it/

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

