### PR TITLE
Issue 69: Security fixes for: minimatch and qs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
   "devDependencies": {
   },
   "overrides": {
-    "glob-stream": "^7.0.0"
+    "glob-stream": "^7.0.0",
+    "minimatch": "^3.1.2",
+    "qs": "^6.11.0"
   }
 }


### PR DESCRIPTION
Fix child dependencies that are coming in with insecure versions. This is based on the `npm list --depth=100` and considers what is reported by dependabot for Sage.

see: https://github.com/TAMULib/SAGE/security/dependabot/37
see: https://github.com/TAMULib/SAGE/security/dependabot/34

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #69

## Type of change

Please delete options that are not relevant.

- [x] Security related.

# How Has This Been Tested?

- [X] Not tested, Needs QA.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings